### PR TITLE
Start dart

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "places",
+            "cwd": "places",
+            "request": "launch",
+            "type": "dart",
+            "program": "lib/start.dart"
+        }
+    ]
+}

--- a/places/lib/start.dart
+++ b/places/lib/start.dart
@@ -118,8 +118,9 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 
+// ignore: must_be_immutable
 class MyFirstWidget extends StatelessWidget {
-  var counter = 0;
+  int counter = 0;
   @override
   Widget build(BuildContext context) {
     counter += 1;

--- a/places/test/widget_test.dart
+++ b/places/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:places/main.dart';
+import 'package:places/start.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
Всё отлично работает!

1. Ошибка компиляции. По умолчанию всегда собирается main.dart.

Пропала кнопка запуска пропала
Сломались тесты: import 'package:places/main.dart';

Target of URI doesn't exist: 'package:places/main.dart'.
Try creating the file referenced by the URI, or Try using a URI for a file that does exist.

The function 'MyApp' isn't defined.
Try importing the library that defines 'MyApp', correcting the name to the name of an existing function, or defining a function named 'MyApp'.

Решение:
Но можно поменять настройки и всё заработает как надо. Для VS: "program": "lib/start.dart"
Поменять импорт в тестах.