### PR TITLE
Work with context

### DIFF
--- a/places/lib/main.dart
+++ b/places/lib/main.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 //import 'package:flutter_svg/flutter_svg.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
 class MyApp extends StatelessWidget {
@@ -11,6 +12,34 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Flutter Demo',
+      theme: ThemeData(
+        // This is the theme of your application.
+        //
+        // Try running your application with "flutter run". You'll see the
+        // application has a blue toolbar. Then, without quitting the app, try
+        // changing the primarySwatch below to Colors.green and then invoke
+        // "hot reload" (press "r" in the console where you ran "flutter run",
+        // or simply save your changes to "hot reload" in a Flutter IDE).
+        // Notice that the counter didn't reset back to zero; the application
+        // is not restarted.
+        primarySwatch: Colors.blue,
+        // This makes the visual density adapt to the platform that you run
+        // the app on. For desktop platforms, the controls will be smaller and
+        // closer together (more dense) than on mobile platforms.
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+      ),
+      home: MyHomePage(
+        title: "Flutter Demo Home Page"
+      ),
+    );
+  }
+}
+
+class App extends StatelessWidget {
+  @override 
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'App Stateless Demo',
       theme: ThemeData(
         // This is the theme of your application.
         //
@@ -120,19 +149,30 @@ class _MyHomePageState extends State<MyHomePage> {
 
 class MyFirstWidget extends StatelessWidget {
   var counter = 0;
+  BuildContext internalContext;
+
   @override
   Widget build(BuildContext context) {
+    internalContext = context;
+    print('Our context ${context.runtimeType}');
     counter += 1;
     /*
       After each hot reload, the counter will be erased. 
       Alwayes: StatelessWidget count 1
     */
     print("StatelessWidget count $counter");
+  
     return Container(
      child: Center(
        child: Text('Hello world!')
      )
     );
+  }
+
+  Type getType() {
+    var contextType = internalContext.runtimeType;
+    print('Our context $contextType');
+    return contextType;
   }
 }
 
@@ -144,8 +184,13 @@ class MyFirsStatefultWidget extends StatefulWidget {
 
 class _MyFirsStatefultWidgetState extends State<MyFirsStatefultWidget> {
   var counter = 0;
+  BuildContext internalContext;
+
   @override
   Widget build(BuildContext context) {
+    internalContext = context;
+    print('Our context ${context.runtimeType}');
+    
     counter += 1;
     /*
       After each hot reload, the counter will be incremented.
@@ -158,5 +203,11 @@ class _MyFirsStatefultWidgetState extends State<MyFirsStatefultWidget> {
        child: Text('Hello world!')
      )
     );
+  }
+
+  Type getType() {
+    var contextType = internalContext.runtimeType;
+    print('Our context $contextType');
+    return contextType;
   }
 }


### PR DESCRIPTION
1. Ошибка компиляции. По умолчанию всегда собирается main.dart.
Но можно поменять настройки и всё заработает как надо. Для VS: "program": "lib/start.dart"

Пропала кнопка запуска пропала
Сломались тесты: import 'package:places/main.dart';


Target of URI doesn't exist: 'package:places/main.dart'.
Try creating the file referenced by the URI, or Try using a URI for a file that does exist.

The function 'MyApp' isn't defined.
Try importing the library that defines 'MyApp', correcting the name to the name of an existing function, or defining a function named 'MyApp'.

4. Некорректное условие. В предыдущем уроке мы не создавли виджетов с параметрами. А автосгенеррированный виджет MyHomePage наследник StatefulWidget.

Если имеется в виду title относящийся  MaterialApp то нигде.

Погугулил эти ссылки, но в симуляторе ничего не отображается.
https://api.flutter.dev/flutter/material/MaterialApp/title.html
https://stackoverflow.com/questions/50615006/flutter-where-is-the-title-of-material-app-used

5. Код как минимум скомпилировался.
Вернёт: StatelessElement
6 StatefulElement.